### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     }


### PR DESCRIPTION
While using typescript, importing the CommandHandler raises the following error:
`Could not find a declaration file for module 'djs-commander'. 'c:/Users/hkaan/code/kogtr/node_modules/djscommander/dist/index.js' implicitly has an 'any' type.
  Try npm i --save-dev @types/djs-commander if it exists or add a new declaration (.d.ts) file containing declare module 'djs-commander'; ts(7016)`

Adding types to the exports fixed the problem.
```json
"exports": {
    ".": {
      "types": "./index.d.ts",
      "require": "./dist/index.js",
      "import": "./dist/index.mjs"
    }
  },
```